### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.project
 /.classpath
 /.settings
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -1,42 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.11</version>
+    <version>4.40</version>
     <relativePath />
   </parent>
-  <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>no-agent-job-purge</artifactId>
   <version>1.3-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <properties>
-    <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>1.625.3</jenkins.version>
-    <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
-    <java.level>7</java.level>
-    <!-- Jenkins Test Harness version you use to test the plugin. -->
-    <!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
-    <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
-    <!-- Other properties you may want to use:
-         ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
-         ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
-    -->
+    <jenkins.version>2.332.2</jenkins.version>
   </properties>
 
   <name>No Agent Job Purge</name>
-  <description>A Jenkins plugin to purge jobs from the build queue if there is no agent available to take it.</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/No+Agent+Job+Purge+Plugin</url>
-
-  <!-- The default licence for Jenkins OSS Plugins is MIT. Substitute for the applicable one if needed. -->
+  <url>https://plugins.jenkins.io/no-agent-job-purge/</url>
 
   <licenses>
     <license>
       <name>MIT License</name>
-      <url>http://opensource.org/licenses/MIT</url>
+      <url>https://opensource.org/licenses/MIT</url>
     </license>
   </licenses>
 
@@ -50,9 +36,9 @@
 
   <!-- Assuming you want to host on @jenkinsci:-->
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+    <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <tag>no-agent-job-purge-1.0</tag>
   </scm>
 
@@ -68,14 +54,5 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-  <!-- If you want to depend on other plugins:
-  <dependencies>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>credentials</artifactId>
-      <version>1.9.4</version>
-    </dependency>
-  </dependencies>
-  -->
 
 </project>

--- a/src/main/java/org/jenkinsci/plugins/noslavejobpurge/PurgeNoAgentJobs.java
+++ b/src/main/java/org/jenkinsci/plugins/noslavejobpurge/PurgeNoAgentJobs.java
@@ -45,7 +45,11 @@ public class PurgeNoAgentJobs implements RootAction {
 
 	@Override
 	public String getIconFileName() {
-		return "/images/32x32/gear2.png";
+		return "null";
+	}
+
+	public String getIconClassName() {
+		return "icon-gear";
 	}
 
 	@Override


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.
In case of your plugin, I've removed the header icons, because that is what modern Jenkins does now look like.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @pbuckley4192 
Thanks in advance!